### PR TITLE
[feature-BNPL-683]: Added order webhooks

### DIFF
--- a/src/Bootstrap/PaymentMethods.php
+++ b/src/Bootstrap/PaymentMethods.php
@@ -15,17 +15,17 @@ class PaymentMethods extends AbstractBootstrap
     public const PAYMENT_METHODS = [
         MonduHandler::class => [
             'handlerIdentifier' => MonduHandler::class,
-            'name' => 'Mondu Invoice',
-            'description' => 'Mondu invoice description',
+            'name' => 'Mondu',
+            'description' => 'Buy now, pay later.',
             'afterOrderEnabled' => false,
             'translations' => [
                 'de-DE' => [
                     'name' => 'Mondu Rechnungskauf',
-                    'description' => 'Mondu invoice description',
+                    'description' => 'Buy now, pay later.',
                 ],
                 'en-GB' => [
                     'name' => 'Mondu invoice',
-                    'description' => 'Mondu invoice description',
+                    'description' => 'Buy now, pay later.',
                 ],
             ],
         ],

--- a/src/Components/PluginConfig/Service/ConfigService.php
+++ b/src/Components/PluginConfig/Service/ConfigService.php
@@ -6,10 +6,10 @@ namespace Mondu\MonduPayment\Components\PluginConfig\Service;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class ConfigService {
-    const API_URL = 'http://localhost:3000/api/v1';
-    const WIDGET_URL = 'http://checkout-sandbox.mondu.local/widget.js';
-    const SANDBOX_API_URL = 'http://localhost:3000/api/v1';
-    const SANDBOX_WIDGET_URL = 'http://checkout-sandbox.mondu.local/widget.js';
+    const API_URL = 'http://api.demo.mondu.ai/api/v1';
+    const WIDGET_URL = 'http://checkout.demo.mondu.ai/widget.js';
+    const SANDBOX_API_URL = 'http://host.docker.internal:3000/api/v1';
+    const SANDBOX_WIDGET_URL = 'http://localhost:3002/widget.js'; // host.docker.internal IP
     /**
      * @var SystemConfigService
      */
@@ -50,6 +50,12 @@ class ConfigService {
         $config = $this->getPluginConfiguration();
 
         return $config['apiToken'] ?? null;
+    }
+
+    public function getWebhooksSecret() {
+      $config = $this->getPluginConfiguration();
+
+      return $config['webhooksSecret'] ?? null;
     }
 
     public function isStateWatchingEnabled(): bool {

--- a/src/Components/StateMachine/Service/StateMachineRegistryDecorator.php
+++ b/src/Components/StateMachine/Service/StateMachineRegistryDecorator.php
@@ -74,8 +74,14 @@ class StateMachineRegistryDecorator extends StateMachineRegistry // we must exte
             $order = $this->getOrder($orderDelivery->getOrderId(), $context);
             $transaction = $order ? $order->getTransactions()->first() : null;
             $paymentMethod = $transaction ? $transaction->getPaymentMethod() : null;
-            if($paymentMethod && MethodHelper::isMonduPayment($paymentMethod) && !$this->canShipOrder($order)) {
-                throw new MonduException('Cant ship the order');
+            $transitionName = $transition->getTransitionName();
+
+            if($paymentMethod &&
+                MethodHelper::isMonduPayment($paymentMethod) &&
+                !$this->canShipOrder($order) &&
+                ($transitionName == 'ship' || $transitionName == 'ship_partially')
+            ) {
+                throw new MonduException('Order can not be shipped.');
             }
         }
 

--- a/src/Components/Webhooks/Controller/WebhooksController.php
+++ b/src/Components/Webhooks/Controller/WebhooksController.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Mondu\MonduPayment\Components\Webhooks\Controller;
+
+use Shopware\Core\Framework\Context;
+use Mondu\MonduPayment\Components\PluginConfig\Service\ConfigService;
+use Mondu\MonduPayment\Components\Webhooks\Service\WebhookService;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+
+/**
+ * @RouteScope(scopes={"storefront"})
+ */
+class WebhooksController extends StorefrontController
+{
+  private ConfigService $configService;
+  private WebhookService $webhookService;
+
+  public function __construct(
+      ConfigService $configService,
+      WebhookService $webhookService
+  ) {
+      $this->configService = $configService;
+      $this->webhookService = $webhookService;
+  }
+
+  /**
+    * @Route("/mondu/webhooks", name="mondu-payment.webhooks", defaults={"csrf_protected"=false}, methods={"POST"})
+    */
+    public function process(Request $request, Context $context): Response
+    {
+      $content = $request->getContent();
+      $headers = $request->headers;
+
+      $signature = hash_hmac('sha256',$content, $this->configService->getWebhooksSecret());
+      if($signature !== @$headers->get('X-Mondu-Signature')) {
+          throw new \Exception('Signature mismatch');
+      }
+
+      $params = json_decode($content, true);
+      $topic = $params['topic'];
+
+      switch ($topic) {
+        case 'order/confirmed':
+            [$resBody, $resStatus] = $this->webhookService->handleConfirmed($params, $context);
+            break;
+        case 'order/pending':
+            [$resBody, $resStatus] = $this->webhookService->handlePending($params, $context);
+            break;
+        case 'order/canceled':
+        case 'order/declined':
+            [$resBody, $resStatus] = $this->webhookService->handleDeclinedOrCanceled($params, $context);
+            break;
+        default:
+            throw new \Exception('Unregistered topic');
+      }
+
+
+      return new Response(
+        json_encode($resBody),
+        $resStatus,
+        ['content-type' => 'application/json']
+      );
+    }
+}

--- a/src/Components/Webhooks/DependencyInjection/controllers.xml
+++ b/src/Components/Webhooks/DependencyInjection/controllers.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+        <defaults autowire="true" >
+            <tag name="controller.service_arguments"/>
+        </defaults>
+
+
+        <service id="Mondu\MonduPayment\Components\Webhooks\Controller\WebhooksController" public="true">
+            <argument key="$configService" type="service" id="mondu.mondu_config"/>
+            <argument key="$webhookService" type="service" id="mondu.webhook_service"/>
+
+            <call method="setContainer">
+                <argument id="service_container" type="service"/>
+            </call>
+        </service>
+
+    </services>
+</container>

--- a/src/Components/Webhooks/DependencyInjection/services.xml
+++ b/src/Components/Webhooks/DependencyInjection/services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults autowire="true"/>
+
+        <service id="mondu.webhook_service" class="Mondu\MonduPayment\Components\Webhooks\Service\WebhookService"/>
+    </services>
+</container>

--- a/src/Components/Webhooks/Service/WebhookService.php
+++ b/src/Components/Webhooks/Service/WebhookService.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace Mondu\MonduPayment\Components\Webhooks\Service;
+
+use Symfony\Component\HttpFoundation\Response;
+use Shopware\Core\System\StateMachine\StateMachineRegistry;
+use Shopware\Core\System\StateMachine\Transition;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Mondu\MonduPayment\Components\StateMachine\Exception\MonduException;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Psr\Log\LoggerInterface;
+
+class WebhookService {
+
+    private StateMachineRegistry $stateMachineRegistry;
+    private EntityRepositoryInterface $orderRepository;
+    private LoggerInterface $logger;
+
+    public function __construct(StateMachineRegistry $stateMachineRegistry, EntityRepositoryInterface $orderRepository, LoggerInterface $logger) {
+      $this->stateMachineRegistry = $stateMachineRegistry;
+      $this->orderRepository = $orderRepository;
+      $this->logger = $logger;
+    }
+    
+    public function handleConfirmed($params = [], $context) : array {
+      try {
+        $viban = @$params['bank_account']['iban'];
+        $monduId = @$params['order_uuid'];
+        $externalReferenceId = @$params['external_reference_id'];
+
+        if(!$viban || !$externalReferenceId) {
+            throw new MonduException('Missing params.');
+        }
+
+        $transitionResult = $this->transitionOrderState($externalReferenceId, 'process', $context);
+
+        return [[ 'status' => $transitionResult->last()->getTechnicalName(), 'error' => 0 ], Response::HTTP_OK];
+      }
+      catch (MonduException $e) {
+        $this->log('handleConfirmed Webhook Failed', [$params], $e);
+        return [[ 'status' => $e->getMessage(), 'error' => 10 ], Response::HTTP_BAD_REQUEST];
+      }
+    }
+
+    public function handlePending($params = [], $context) : array {
+      try {
+        
+        $externalReferenceId = @$params['external_reference_id'];
+        $monduId = @$params['order_uuid'];
+
+        if(!$externalReferenceId || !$monduId) {
+            throw new MonduException('Required params missing');
+        }
+
+        $transitionResult = $this->transitionOrderState($externalReferenceId, 'process', $context);
+
+        return [[ 'status' => $transitionResult->last()->getTechnicalName(), 'error' => 0 ], Response::HTTP_OK];
+      }
+      catch (MonduException $e) {
+        $this->log('handlePending Webhook Failed', [$params], $e);
+        return [[ 'status' => 'error', 'error' => 10 ], Response::HTTP_BAD_REQUEST];
+      }
+    }
+
+    public function handleDeclinedOrCanceled($params = [], $context) : array {
+      try {
+        $monduId = @$params['order_uuid'];
+        $externalReferenceId = @$params['external_reference_id'];
+        $orderState = @$params['order_state'];
+
+        if(!$monduId || !$externalReferenceId || !$orderState) {
+            $this->log('Required params missing', [$monduId, $externalReferenceId, $orderState]);
+            throw new MonduException('Required params missing');
+        }
+
+        $transitionResult = $this->transitionOrderState($externalReferenceId, 'cancel', $context);
+        $transitionResult = $this->transitionDeliveryState($externalReferenceId, 'cancel', $context);
+        $transitionResult = $this->transitionTransactionState($externalReferenceId, 'cancel', $context);
+
+        return [[ 'status' => $transitionResult->last()->getTechnicalName(), 'error' => 0 ], Response::HTTP_OK];
+      }
+      catch (MonduException $e) {
+        $this->log('handleDeclinedOrCanceled Webhook Failed', [$params], $e);
+        return [[ 'status' => $e->getMessage(), 'error' => 10 ], Response::HTTP_BAD_REQUEST];
+      } 
+    }
+
+    protected function transitionOrderState($externalReferenceId, $state, $context) {
+      try {
+        return $this->stateMachineRegistry->transition(new Transition(
+          OrderDefinition::ENTITY_NAME,
+          $this->getOrderUuid($externalReferenceId, $context),
+          $state,
+          'stateId'
+        ), $context);
+      }
+      catch (\Exception $e) {
+        $this->log('transitionOrderState Failed', [$externalReferenceId, $state], $e);
+        throw new MonduException($e->getMessage());
+      }
+    }
+
+    protected function transitionDeliveryState($externalReferenceId, $state, $context) {
+      try {
+        $criteria = new Criteria([$this->getOrderUuid($externalReferenceId, $context)]);
+        $criteria->addAssociation('deliveries');
+
+        /** @var OrderEntity $orderEntity */
+        $orderEntity = $this->orderRepository->search($criteria, $context)->first();
+        $orderDeliveryId = $orderEntity->getDeliveries()->first()->getId();
+    
+        return $this->stateMachineRegistry->transition(new Transition(
+            OrderDeliveryDefinition::ENTITY_NAME,
+            $orderDeliveryId,
+            $state,
+            'stateId'
+        ), $context);
+      }
+      catch (\Exception $e) {
+        $this->log('transitionDeliveryState Failed', [$externalReferenceId, $state], $e);
+        throw new MonduException($e->getMessage());
+      }
+    }
+
+    protected function transitionTransactionState($externalReferenceId, $state, $context) {
+      try {
+        $criteria = new Criteria([$this->getOrderUuid($externalReferenceId, $context)]);
+        $criteria->addAssociation('transactions');
+
+        /** @var OrderEntity $orderEntity */
+        $orderEntity = $this->orderRepository->search($criteria, $context)->first();
+        $orderTransactionId = $orderEntity->getTransactions()->first()->getId();
+    
+        return $this->stateMachineRegistry->transition(new Transition(
+            OrderTransactionDefinition::ENTITY_NAME,
+            $orderTransactionId,
+            $state,
+            'stateId'
+        ), $context);
+      }
+      catch (\Exception $e) {
+        $this->log('transitionTransactionState Failed', [$externalReferenceId, $state], $e);
+        throw new MonduException($e->getMessage());
+      }
+    }
+
+    protected function getOrderUuid($externalReferenceId, $context) {
+      try {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('orderNumber', $externalReferenceId));  
+
+        $orderId = $this->orderRepository->search($criteria, $context)->first()->getId();
+
+        return $orderId;
+      }
+      catch (\Exception $e) {
+        $this->log('getOrderUuid Failed', [$externalReferenceId], $e);
+        throw new MonduException($e->getMessage());
+      }
+    }
+
+    protected function log($message, $data, $exception = null) {
+      $exceptionMessage = "";
+
+      if ($exception != null) {
+        $exceptionMessage = $exception->getMessage();
+      }
+
+      $this->logger->critical(
+        $message . '. (Exception: '. $exceptionMessage .')',
+        $data
+      );
+    }
+}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -15,11 +15,16 @@
     </card>
 
     <card>
-        <title>Mondu api key</title>
+        <title>Mondu API Configuration</title>
 
         <input-field type="password">
             <name>apiToken</name>
-            <label>Api key</label>
+            <label>API Key</label>
+        </input-field>
+
+        <input-field type="password">
+            <name>webhooksSecret</name>
+            <label>Webhooks Secret</label>
         </input-field>
 
         <component name="mondu-test-credentials-button">


### PR DESCRIPTION
This PR adds several new features:
- Added Webhooks Secret field into the plugin configuration
- Added webhooks endpoint `/mondu/webhooks` which handles topics below:
- - order/confirmed
- - order/pending
- - order/canceled
- - order/declined
