### PR TITLE
Removed webhooks secret from plugin configuration

### DIFF
--- a/src/Components/PluginConfig/Service/ConfigService.php
+++ b/src/Components/PluginConfig/Service/ConfigService.php
@@ -68,6 +68,11 @@ class ConfigService
         return $config['webhooksSecret'] ?? null;
     }
 
+    public function setWebhooksSecret($secret = '')
+    {
+        return $this->systemConfigService->set('MonduPayment.config.webhooksSecret', $secret);
+    }
+
     public function isStateWatchingEnabled(): bool
     {
         $config = $this->getPluginConfiguration();

--- a/src/Components/Webhooks/DependencyInjection/services.xml
+++ b/src/Components/Webhooks/DependencyInjection/services.xml
@@ -9,6 +9,7 @@
           <argument key="$logger" type="service" id="mondu.logger"/>
           <argument key="$monduClient" type="service" id="mondu.mondu_api"/>
           <argument key="$orderDataRepository" type="service" id="mondu_order_data.repository"/>
+          <argument key="$configService" type="service" id="mondu.mondu_config"/>
         </service>
 
         <service id="Mondu\MonduPayment\Components\Webhooks\Subscriber\ConfigSubscriber">

--- a/src/Components/Webhooks/Subscriber/ConfigSubscriber.php
+++ b/src/Components/Webhooks/Subscriber/ConfigSubscriber.php
@@ -56,9 +56,11 @@ class ConfigSubscriber implements EventSubscriberInterface
         foreach ($event->getWriteResults() as $result) {
             $changeSet = $result->getChangeSet();
 
-            if ($changeSet != null
-                && $changeSet->hasChanged('configuration_value')
-                && $changeSet->getBefore('configuration_key') == 'MonduPayment.config.apiToken') {  
+            if ($result->getProperty('configurationKey') == 'MonduPayment.config.apiToken')
+            {  
+                    $key = $result->getProperty('configurationValue');
+
+                    $this->webhookService->getSecret($key, $event->getContext());
                     $this->webhookService->register($event->getContext());
             }
 

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -23,11 +23,6 @@
             <label>API Key</label>
         </input-field>
 
-        <input-field type="password">
-            <name>webhooksSecret</name>
-            <label>Webhooks Secret</label>
-        </input-field>
-
         <component name="mondu-test-credentials-button">
             <name>testLiveClientCredentialsButton</name>
             <apiMode>live</apiMode>


### PR DESCRIPTION
This PR removes the webhooks secret field from the plugin configuration in order to make integrations with merchants easier. 