### PR TITLE
Fixed plugin conflicts, order id reservation and a configuration flag

### DIFF
--- a/src/Components/Checkout/Controller/CheckoutController.php
+++ b/src/Components/Checkout/Controller/CheckoutController.php
@@ -42,11 +42,7 @@ class CheckoutController extends StorefrontController
     {
         $paymentMethod = MethodHelper::monduPaymentMethodOrDefault($request->get('payment_method'));
 
-        $orderNumber = $numberRangeValueGenerator->getValue(
-            'order',
-            $salesChannelContext->getContext(),
-            $salesChannelContext->getSalesChannel()->getId()
-        );
+        $orderNumber = uniqid('M_SW6_');
 
         $cart = $cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
 

--- a/src/Components/MonduApi/Service/MonduClient.php
+++ b/src/Components/MonduApi/Service/MonduClient.php
@@ -88,6 +88,19 @@ class MonduClient
         }
     }
 
+    public function updateExternalInfo($orderUuid, $body = []): ?array
+    {
+        $request = $this->getRequestObject('orders/'. $orderUuid.'/update_external_info', 'POST', json_encode($body));
+        try {
+            $response = $this->restClient->send($request);
+            $body = json_decode($response->getBody()->getContents(), true);
+            return $body;
+        } catch (GuzzleException $e) {
+            $this->logger->alert('MonduClient::updateExternalInfo Failed with an exception message: ' . $e->getMessage());
+            return null;
+        }
+    }
+
     public function cancelInvoice($orderUuid, $invoiceUuid): ?array
     {
         $request = $this->getRequestObject('orders/'. $orderUuid.'/invoices/' . $invoiceUuid . '/cancel', 'POST');

--- a/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
+++ b/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
@@ -87,7 +87,11 @@ class AdjustOrderSubscriber implements EventSubscriberInterface
                     $criteria = new Criteria();
                     $criteria->addFilter(new EqualsFilter('orderId', $orderId));
                     $monduOrderEntity = $this->orderDataRepository->search($criteria, $context)->first();
-
+                    
+                    if (!isset($monduOrderEntity)) {
+                        return;
+                    }
+                        
                     if ($monduOrderEntity->getOrderState() == 'canceled') {
                         $this->transitionDeliveryState($orderId, 'cancel', $context);
                     }

--- a/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
+++ b/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
@@ -43,15 +43,16 @@ class MonduHandler implements SynchronousPaymentHandlerInterface
         if (!$monduOrder) {
             throw new SyncPaymentProcessException($transaction->getOrderTransaction()->getId(), 'unknown error during payment');
         }
-        $this->orderRepository->update([
-            [
-                'id' => $order->getId(),
-                'orderNumber' => $monduOrder['external_reference_id']
-            ]
-        ], $salesChannelContext->getContext());
 
-//        $context = $salesChannelContext->getContext();
-//        $this->transactionStateHandler->paid($transaction->getOrderTransaction()->getId(), $context);
+        // Update external reference id on Mondu
+
+        $this->monduClient
+                ->setSalesChannelId($salesChannelContext->getSalesChannelId())
+                ->updateExternalInfo(
+                    $monduData->get('order-id'),
+                    ['external_reference_id' => $order->getOrderNumber()]
+                );
+
 
         $this->orderDataRepository->upsert([
             [

--- a/src/Components/PaymentMethod/PaymentHandler/MonduSepaHandler.php
+++ b/src/Components/PaymentMethod/PaymentHandler/MonduSepaHandler.php
@@ -43,12 +43,14 @@ class MonduSepaHandler implements SynchronousPaymentHandlerInterface
             throw new SyncPaymentProcessException($transaction->getOrderTransaction()->getId(), 'unknown error during payment');
         }
 
-        $this->orderRepository->update([
-            [
-                'id' => $order->getId(),
-                'orderNumber' => $monduOrder['external_reference_id']
-            ]
-        ], $salesChannelContext->getContext());
+        // Update external reference id on Mondu
+
+        $this->monduClient
+                ->setSalesChannelId($salesChannelContext->getSalesChannelId())
+                ->updateExternalInfo(
+                    $monduData->get('order-id'),
+                    ['external_reference_id' => $order->getOrderNumber()]
+                );
 
         $this->orderDataRepository->upsert([
             [

--- a/src/Components/PluginConfig/Service/ConfigService.php
+++ b/src/Components/PluginConfig/Service/ConfigService.php
@@ -88,6 +88,13 @@ class ConfigService
         return $config['apiTokenValid'] ?? false;
     }
 
+    public function skipOrderStateValidation()
+    {
+        $config = $this->getPluginConfiguration();
+
+        return $config['skipOrderStateValidation'] ?? false;
+    }
+
     public function setWebhooksSecret($secret = '')
     {
         return $this->systemConfigService->set('Mond1SW6.customConfig.webhooksSecret', $secret, $this->salesChannelId);

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -3,8 +3,7 @@
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
 
     <card>
-        <title>API Mode</title>
-        <title lang="de-DE">API Modus</title>
+        <title>Mondu API Configuration</title>
 
         <input-field type="bool">
             <name>sandbox</name>
@@ -13,10 +12,6 @@
             <value>0</value>
             <defaultValue>1</defaultValue>
         </input-field>
-    </card>
-
-    <card>
-        <title>Mondu API Configuration</title>
 
         <input-field type="password">
             <name>apiToken</name>
@@ -28,5 +23,18 @@
             <label>Validate API Credentials</label>
             <apiMode>live</apiMode>
         </component>
+    </card>
+
+    <card>
+        <title>Mondu Configuration</title>
+        <title lang="de-DE">API Modus</title>
+
+        <input-field type="bool">
+            <name>skipOrderStateValidation</name>
+            <label>Skip order state validation?</label>
+            <value>0</value>
+            <defaultValue>0</defaultValue>
+            <helpText>When this flag is enabled, there will be no validations such as invoice validation upon changing an order state.</helpText>
+        </input-field>
     </card>
 </config>


### PR DESCRIPTION
- Removed order id reservation if Mondu Order is canceled/declined in the widget
- Fixed Mondu plugin interfering with Orders that are not paid by Mondu (shipping an order)
- Added a flag to plugin configuration to enable create invoice by changing order state to shipped 