### PR TITLE
Fix document controller

### DIFF
--- a/src/Components/Order/Controller/DocumentController.php
+++ b/src/Components/Order/Controller/DocumentController.php
@@ -6,6 +6,8 @@ namespace Mondu\MonduPayment\Components\Order\Controller;
 
 use Mondu\MonduPayment\Components\Order\Util\DocumentUrlHelper;
 use Shopware\Core\Checkout\Document\DocumentService;
+use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
+use Shopware\Core\Checkout\Document\Service\DocumentMerger;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
@@ -22,10 +24,12 @@ class DocumentController extends \Shopware\Core\Checkout\Document\Controller\Doc
 
     public function __construct(
         DocumentService $documentService,
+        DocumentGenerator $documentGenerator,
+        DocumentMerger $documentMerger,
         EntityRepositoryInterface $documentRepository,
         DocumentUrlHelper $documentUrlHelper
     ) {
-        parent::__construct($documentService, $documentRepository);
+        parent::__construct($documentService, $documentGenerator, $documentMerger, $documentRepository);
         $this->documentUrlHelper = $documentUrlHelper;
     }
 


### PR DESCRIPTION
## Description

The document controller changed between version 6.4.13.0 and 6.4.14.0.

https://github.com/shopware/platform/blob/v6.4.13.0/src/Core/Checkout/Document/Controller/DocumentController.php
https://github.com/shopware/platform/blob/v6.4.14.0/src/Core/Checkout/Document/Controller/DocumentController.php

This results in the following error when retrieving in invoice via:
https://domain.xyz/mondu/document/{documentId}/{deepLinkCode}/{token}

`request.CRITICAL: Uncaught PHP Exception TypeError: "Shopware\Core\Checkout\Document\Controller\DocumentController::__construct(): Argument #2 ($documentGenerator) must be of type Shopware\Core\Checkout\Document\Service\DocumentGenerator, Shopware\Core\Framework\DataAbstractionLayer\EntityRepository given, called in /var/domains/our-client/releases/20230414-100140-498b29e830969a7bb88a1939f080415f8dcb5498/vendor/mondu/shopware6-payment/src/Components/Order/Controller/DocumentController.php on line 28"
`

How can this have gone unnoticed for 9+ months? 
