### PR TITLE
Document controller fix for 6.4.14 +

### DIFF
--- a/src/Components/Order/Controller/DocumentController.php
+++ b/src/Components/Order/Controller/DocumentController.php
@@ -5,36 +5,22 @@ declare(strict_types=1);
 namespace Mondu\MonduPayment\Components\Order\Controller;
 
 use Mondu\MonduPayment\Components\Order\Util\DocumentUrlHelper;
-use Shopware\Core\Checkout\Document\DocumentService;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @RouteScope(scopes={"storefront"})
  */
 class DocumentController extends \Shopware\Core\Checkout\Document\Controller\DocumentController
 {
-    private DocumentUrlHelper $documentUrlHelper;
-
-    public function __construct(
-        DocumentService $documentService,
-        EntityRepositoryInterface $documentRepository,
-        DocumentUrlHelper $documentUrlHelper
-    ) {
-        parent::__construct($documentService, $documentRepository);
-        $this->documentUrlHelper = $documentUrlHelper;
-    }
-
     /**
      * @Route(name="mondu-payment.payment.document", path="/mondu/document/{documentId}/{deepLinkCode}/{token}")
      */
     public function downloadDocument(Request $request, string $documentId, string $deepLinkCode, Context $context): Response
     {
-        if ($this->documentUrlHelper->getToken() !== $request->attributes->get('token')) {
+        $documentUrlHelper = $this->container->get(DocumentUrlHelper::class);
+        if ($documentUrlHelper->getToken() !== $request->attributes->get('token')) {
             throw $this->createNotFoundException();
         }
 


### PR DESCRIPTION
## Description

This PR removes __construct from DocumentController, so dependencies are autowired.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
