### PR TITLE
[PT-1159] Fix 500 webhook responses when the order is not found.

### DIFF
--- a/src/Components/StateMachine/Exception/MonduException.php
+++ b/src/Components/StateMachine/Exception/MonduException.php
@@ -9,8 +9,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MonduException extends ShopwareHttpException
 {
-    public function __construct($message)
+    private int $monduStatusCode;
+
+    public function __construct($message, $statusCode = Response::HTTP_BAD_REQUEST)
     {
+        $this->monduStatusCode = $statusCode;
         parent::__construct(
             $message
         );
@@ -23,6 +26,6 @@ class MonduException extends ShopwareHttpException
 
     public function getStatusCode(): int
     {
-        return Response::HTTP_BAD_REQUEST;
+        return $this->monduStatusCode;
     }
 }


### PR DESCRIPTION
## Description

Fix for webhooks controller returning 500 status when order is not found.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
