### PR TITLE
Set names of commands

### DIFF
--- a/src/Command/ActivatePaymentCommand.php
+++ b/src/Command/ActivatePaymentCommand.php
@@ -31,6 +31,7 @@ class ActivatePaymentCommand extends Command
 
     protected function configure(): void
     {
+        $this->setName(self::$defaultName);
         $this->setDescription('Adds Mondu Payment methods to the sales channels.');
     }
 

--- a/src/Command/ConfigApiTokenCommand.php
+++ b/src/Command/ConfigApiTokenCommand.php
@@ -20,6 +20,7 @@ class ConfigApiTokenCommand extends Command
 
     protected function configure(): void
     {
+        $this->setName(self::$defaultName);
         $this->setDescription('Adds API token to plugin configuration.');
         $this->addArgument(
             'api_token',

--- a/src/Command/TestApiTokenCommand.php
+++ b/src/Command/TestApiTokenCommand.php
@@ -21,6 +21,7 @@ class TestApiTokenCommand extends Command
 
     protected function configure(): void
     {
+        $this->setName(self::$defaultName);
         $this->setDescription('Tests if API token is valid.');
         $this->addArgument(
             'api_token',


### PR DESCRIPTION
## Description

```                                                
[WARNING] Some commands could not be registered:

In Application.php line 535:
                                                                                                        
  [Symfony\Component\Console\Exception\LogicException]                                                  
  The command defined in "Mondu\MonduPayment\Command\ConfigApiTokenCommand" cannot have an empty name.  
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works
