### PR TITLE
PT-1413: Mondu orders can no longer be loaded if a product referenced…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mondu/shopware6-payment",
   "description": "Mondu payment for Shopware 6",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "shopware-platform-plugin",
   "license": "proprietary",
   "authors": [

--- a/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
+++ b/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
@@ -133,7 +133,7 @@ class AdjustOrderSubscriber implements EventSubscriberInterface
 
                     $lineItems[] = [
                         'external_reference_id' => $lineItem->getReferencedId(),
-                        'product_id' => $product->getProductNumber(),
+                        'product_id' => $lineItem->getPayload()['productNumber'],
                         'quantity' => $lineItem->getQuantity(),
                         'title' => $lineItem->getLabel(),
                         'net_price_cents' => round($unitNetPrice * $lineItem->getQuantity()),

--- a/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
+++ b/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
@@ -206,7 +206,7 @@ class MonduHandler implements AsynchronousPaymentHandlerInterface
 
             $lineItems[] = [
                 'external_reference_id' => $lineItem->getReferencedId(),
-                'product_id' => $product->getProductNumber(),
+                'product_id' => $lineItem->getPayload()['productNumber'],
                 'quantity' => $lineItem->getQuantity(),
                 'title' => $lineItem->getLabel(),
                 'net_price_cents' => round($unitNetPrice * $lineItem->getQuantity()),


### PR DESCRIPTION
## Description

This PR is changing the approach to creating the line item product ID. Before this update the ID is taken from the product, after the update we are getting this ID from the line item's payload

Release: p
Tickets: PT-1413

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-1413

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
