### PR TITLE
PT-1622: Plugin does not sent all the buyer data for logged in buyers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mondu/shopware6-payment",
   "description": "Mondu payment for Shopware 6",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "shopware-platform-plugin",
   "license": "proprietary",
   "authors": [

--- a/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
+++ b/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
@@ -138,7 +138,10 @@ class MonduHandler implements AsynchronousPaymentHandlerInterface
                 'phone' => $order->getBillingAddress()->getPhoneNumber(),
                 'address_line1' => $order->getBillingAddress()->getStreet(),
                 'zip_code' => $order->getBillingAddress()->getZipCode(),
-                'is_registered' => !$order->getOrderCustomer()->getCustomer()->getGuest()
+                'external_reference_id' => $order->getOrderCustomer()->getCustomer()->getCustomerNumber(),
+                'account_created_at' => !$order->getOrderCustomer()->getCustomer()->getCreatedAt(),
+                'account_updated_at' => !$order->getOrderCustomer()->getCustomer()->getUpdatedAt(),
+
             ],
             'billing_address' => [
                 'address_line1' => $order->getBillingAddress()->getStreet(),

--- a/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
+++ b/src/Components/PaymentMethod/PaymentHandler/MonduHandler.php
@@ -138,9 +138,10 @@ class MonduHandler implements AsynchronousPaymentHandlerInterface
                 'phone' => $order->getBillingAddress()->getPhoneNumber(),
                 'address_line1' => $order->getBillingAddress()->getStreet(),
                 'zip_code' => $order->getBillingAddress()->getZipCode(),
+                'is_registered' => !$order->getOrderCustomer()->getCustomer()->getGuest(),
                 'external_reference_id' => $order->getOrderCustomer()->getCustomer()->getCustomerNumber(),
-                'account_created_at' => !$order->getOrderCustomer()->getCustomer()->getCreatedAt(),
-                'account_updated_at' => !$order->getOrderCustomer()->getCustomer()->getUpdatedAt(),
+                'account_created_at' => $order->getOrderCustomer()->getCustomer()->getCreatedAt(),
+                'account_updated_at' => $order->getOrderCustomer()->getCustomer()->getUpdatedAt(),
 
             ],
             'billing_address' => [


### PR DESCRIPTION
## Description

This PR is adding attributes to be sent with the order object for the logged-in customer.

Release: m
Tickets: PT-1622

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-1622

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
