### PR TITLE
[PT-1842] Handle transitionOrderState and transitionDeliveryState errors gracefully

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mondu/shopware6-payment",
   "description": "Mondu payment for Shopware 6",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "shopware-platform-plugin",
   "license": "proprietary",
   "authors": [

--- a/src/Components/Webhooks/Service/WebhookService.php
+++ b/src/Components/Webhooks/Service/WebhookService.php
@@ -168,7 +168,7 @@ class WebhookService
         }
     }
 
-    protected function transitionOrderState($externalReferenceId, $state, $context, $monduId = null): StateMachineStateCollection
+    protected function transitionOrderState($externalReferenceId, $state, $context, $monduId = null): ?StateMachineStateCollection
     {
         try {
             return $this->stateMachineRegistry->transition(new Transition(
@@ -177,15 +177,13 @@ class WebhookService
                 $state,
                 'stateId'
             ), $context);
-        } catch (MonduException $e) {
-            throw $e;
         } catch (\Exception $e) {
             $this->log('transitionOrderState Failed', [$externalReferenceId, $state], $e);
-            throw new MonduException($e->getMessage());
+            return null;
         }
     }
 
-    protected function transitionDeliveryState($externalReferenceId, $state, $context, $monduId = null): StateMachineStateCollection
+    protected function transitionDeliveryState($externalReferenceId, $state, $context, $monduId = null): ?StateMachineStateCollection
     {
         try {
             $criteria = new Criteria([$this->getOrderUuid($externalReferenceId, $context, $monduId)]);
@@ -201,11 +199,9 @@ class WebhookService
                 $state,
                 'stateId'
             ), $context);
-        } catch (MonduException $e) {
-            throw $e;
         } catch (\Exception $e) {
             $this->log('transitionDeliveryState Failed', [$externalReferenceId, $state], $e);
-            throw new MonduException($e->getMessage());
+            return null;
         }
     }
 


### PR DESCRIPTION
## Description

 Handle transitionOrderState and transitionDeliveryState errors gracefully. Return success status from webhooks if they fail.

Fixes # (issue)

## Release information

Release: p
Tickets: PT-1842

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] I have added tests that prove my fix is effective or that my feature works
