### PR TITLE
PT-2588: The order status is not updated after the status is set from PENDING to CONFIRMED

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mondu/shopware6-payment",
   "description": "Mondu payment for Shopware 6",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "shopware-platform-plugin",
   "license": "proprietary",
   "authors": [

--- a/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
+++ b/src/Components/Order/Subscriber/AdjustOrderSubscriber.php
@@ -100,7 +100,9 @@ class AdjustOrderSubscriber implements EventSubscriberInterface
                     return;
                 }
 
-                $liveOrder = $this->monduClient->getMonduOrder($monduOrderEntity->getReferenceId());
+                $liveOrder = $this->monduClient
+                    ->setSalesChannelId($order->getSalesChannelId())
+                    ->getMonduOrder($monduOrderEntity->getReferenceId());
 
                 if (!isset($liveOrder['real_price_cents'])) {
                     $this->logger->critical(


### PR DESCRIPTION
## Description

This PR is introducing a new configuration option for the invoice flow.

Release: m
Tickets: PT-2588

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-2588

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
